### PR TITLE
feat: support `*args` and `**kwargs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ from datetime import date
 def create_post(id: int, *, title: str, desc: str | None = None):
     """Create a blog post."""
 
-def delete_post(ids: list[int]):
+def delete_post(*ids: int):
     """Delete blog posts."""
 
 def list_posts(*, between: tuple[date, date] | None = None):
@@ -380,7 +380,7 @@ class Post(feud.Group):
     def create(id: int, *, title: str, desc: str | None = None):
         """Create a blog post."""
 
-    def delete(ids: list[int]):
+    def delete(*ids: int):
         """Delete blog posts."""
 
     def list(*, between: tuple[date, date] | None = None):

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ class Post(feud.Group):
     def create(id: int, *, title: str, desc: str | None = None):
         """Create a blog post."""
 
-    def delete(ids: list[int]):
+    def delete(*ids: int):
         """Delete blog posts."""
 
     def list(*, between: tuple[date, date] | None = None):

--- a/feud/core/command.py
+++ b/feud/core/command.py
@@ -119,7 +119,7 @@ def command(
     return decorate(func) if func else decorate
 
 
-def build_command_state(
+def build_command_state(  # noqa: PLR0915
     state: _command.CommandState, *, func: callable, config: Config
 ) -> None:
     doc: docstring_parser.Docstring
@@ -222,6 +222,25 @@ def build_command_state(
                 meta.kwargs["default"] = _types.defaults.convert_default(
                     spec.default
                 )
+        elif spec.kind == spec.VAR_POSITIONAL:
+            # function positional arguments correspond to CLI arguments
+            meta.type = _command.ParameterType.ARGUMENT
+
+            # add the argument
+            meta.args = [name]
+
+            # special handling for variable-length collections
+            meta.kwargs["nargs"] = -1
+
+            # special handling for feud.typing.custom counting types
+            if custom.is_counter(meta.hint):
+                msg = (
+                    "Counting may only be used in conjunction with "
+                    "keyword-only function parameters (command-line "
+                    "options), not positional function parameters "
+                    "(command-line arguments)."
+                )
+                raise feud.exceptions.CompilationError(msg)
 
         # add the parameter
         if meta.type == _command.ParameterType.ARGUMENT:

--- a/tests/unit/test_core/test_command.py
+++ b/tests/unit/test_core/test_command.py
@@ -356,3 +356,36 @@ Options:
   --help              Show this message and exit.
         """.strip()
     )
+
+
+def test_full_signature(capsys: pytest.CaptureFixture) -> None:
+    @feud.command
+    def f(
+        a: float,
+        /,
+        b: str,
+        *ints: t.PositiveInt,
+        c: int,
+        d: bool = True,
+        **floats: float,
+    ) -> None:
+        """Does something.\f
+
+        Parameters
+        ----------
+        a:
+            Test 1.
+        b:
+            Test 2.
+        *ints:
+            Test 3.
+        c:
+            Test 4.
+        d:
+            Test 5.
+        **floats:
+            Test 6.
+        """
+        return a, b, ints, c, d, floats
+
+    breakpoint()  # noqa: T100

--- a/tests/unit/test_core/test_command.py
+++ b/tests/unit/test_core/test_command.py
@@ -358,16 +358,18 @@ Options:
     )
 
 
-def test_full_signature(capsys: pytest.CaptureFixture) -> None:
+def test_full_signature(  # noqa: PLR0915
+    capsys: pytest.CaptureFixture,
+) -> None:
     @feud.command
-    def f(
+    def command(
         a: float,
         /,
         b: str,
-        *ints: t.PositiveInt,
-        c: int,
-        d: bool = True,
-        **floats: float,
+        *c: t.PositiveInt,
+        d: int,
+        e: bool = True,
+        **f: float,
     ) -> None:
         """Does something.\f
 
@@ -377,15 +379,71 @@ def test_full_signature(capsys: pytest.CaptureFixture) -> None:
             Test 1.
         b:
             Test 2.
-        *ints:
+        *c:
             Test 3.
-        c:
-            Test 4.
         d:
+            Test 4.
+        e:
             Test 5.
-        **floats:
+        **f:
             Test 6.
         """
-        return a, b, ints, c, d, floats
+        return a, b, c, d, e, f
 
-    breakpoint()  # noqa: T100
+    # check params (**f should be ignored)
+    params = command.params
+    assert len(params) == 5
+
+    a = command.params[0]
+    assert isinstance(a, click.Argument)
+    assert a.name == "a"
+    assert a.type == click.FLOAT
+    assert a.opts == ["a"]
+    assert a.secondary_opts == []
+    assert a.nargs == 1
+    assert a.required
+    assert a.default is None
+
+    b = command.params[1]
+    assert isinstance(b, click.Argument)
+    assert b.name == "b"
+    assert b.type == click.STRING
+    assert b.opts == ["b"]
+    assert b.secondary_opts == []
+    assert b.nargs == 1
+    assert b.required
+    assert b.default is None
+
+    c = command.params[2]
+    assert isinstance(c, click.Argument)
+    assert c.name == "c"
+    assert isinstance(c.type, click.IntRange)
+    assert c.type.min == 0
+    assert c.type.min_open
+    assert c.opts == ["c"]
+    assert c.secondary_opts == []
+    assert c.nargs == -1
+    assert not c.required
+    assert c.default is None
+
+    d = command.params[3]
+    assert isinstance(d, click.Option)
+    assert d.name == "d"
+    assert d.help == "Test 4."
+    assert d.type == click.INT
+    assert d.opts == ["--d"]
+    assert d.secondary_opts == []
+    assert d.nargs == 1
+    assert d.required
+    assert d.default is None
+
+    e = command.params[4]
+    assert isinstance(e, click.Option)
+    assert e.name == "e"
+    assert e.help == "Test 5."
+    assert e.type == click.BOOL
+    assert e.opts == ["--e"]
+    assert e.secondary_opts == ["--no-e"]
+    assert e.nargs == 1
+    assert not e.required
+    assert e.default is True

--- a/tests/unit/test_internal/test_decorators.py
+++ b/tests/unit/test_internal/test_decorators.py
@@ -22,6 +22,8 @@ def test_validate_call_single_invalid() -> None:
     param_renames = {}
     meta_vars = {"arg2": "--arg2"}
     sensitive_vars = {"arg2": False}
+    positional = []
+    var_positional = None
     pydantic_kwargs = {}
 
     def f(*, arg2: t.Literal["a", "b", "c"]) -> None:
@@ -34,6 +36,8 @@ def test_validate_call_single_invalid() -> None:
             param_renames=param_renames,
             meta_vars=meta_vars,
             sensitive_vars=sensitive_vars,
+            positional=positional,
+            var_positional=var_positional,
             pydantic_kwargs=pydantic_kwargs,
         )(arg2="invalid")
 
@@ -55,6 +59,8 @@ def test_validate_call_multiple_invalid() -> None:
     param_renames = {}
     meta_vars = {"0": "ARG1", "arg2": "--arg2"}
     sensitive_vars = {"0": False, "arg2": False}
+    positional = []
+    var_positional = None
     pydantic_kwargs = {}
 
     def f(arg1: int, *, arg2: t.Literal["a", "b", "c"]) -> None:
@@ -67,6 +73,8 @@ def test_validate_call_multiple_invalid() -> None:
             param_renames=param_renames,
             meta_vars=meta_vars,
             sensitive_vars=sensitive_vars,
+            positional=positional,
+            var_positional=var_positional,
             pydantic_kwargs=pydantic_kwargs,
         )("invalid", arg2="invalid")
 
@@ -90,6 +98,8 @@ def test_validate_call_list() -> None:
     param_renames = {}
     meta_vars = {"0": "[ARG1]..."}
     sensitive_vars = {"0": False}
+    positional = []
+    var_positional = None
     pydantic_kwargs = {}
 
     def f(arg1: list[t.conint(multiple_of=2)]) -> None:
@@ -102,6 +112,8 @@ def test_validate_call_list() -> None:
             param_renames=param_renames,
             meta_vars=meta_vars,
             sensitive_vars=sensitive_vars,
+            positional=positional,
+            var_positional=var_positional,
             pydantic_kwargs=pydantic_kwargs,
         )([1, 2, 3])
 
@@ -125,6 +137,8 @@ def test_validate_call_enum() -> None:
     param_renames = {}
     meta_vars = {"arg2": "--arg2"}
     sensitive_vars = {"arg2": False}
+    positional = []
+    var_positional = None
     pydantic_kwargs = {}
 
     class Choice(enum.Enum):
@@ -142,6 +156,8 @@ def test_validate_call_enum() -> None:
             param_renames=param_renames,
             meta_vars=meta_vars,
             sensitive_vars=sensitive_vars,
+            positional=positional,
+            var_positional=var_positional,
             pydantic_kwargs=pydantic_kwargs,
         )(arg2="invalid")
 
@@ -163,6 +179,8 @@ def test_validate_call_datetime() -> None:
     param_renames = {}
     meta_vars = {"time": "--time"}
     sensitive_vars = {"time": False}
+    positional = []
+    var_positional = None
     pydantic_kwargs = {}
 
     def f(*, time: t.FutureDatetime) -> None:
@@ -175,6 +193,8 @@ def test_validate_call_datetime() -> None:
             param_renames=param_renames,
             meta_vars=meta_vars,
             sensitive_vars=sensitive_vars,
+            positional=positional,
+            var_positional=var_positional,
             pydantic_kwargs=pydantic_kwargs,
         )(time=t.datetime.now())
 


### PR DESCRIPTION
- `*args` is fully supported.
- `**kwargs` are ignored, as there is no easy way for a Click command to accept arbitrary options without having to individually call `click.option` for each one (which is impossible as this information is not known at compile time).