### PR TITLE
feat: show argument help by default + support `rich-click` overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,6 +796,13 @@ To install Feud without any optional dependencies, simply run `pip install feud`
 
 Below is a comparison of Feud with and without `rich-click`.
 
+> [!TIP]
+> [Settings for `rich-click`](https://github.com/ewels/rich-click/blob/main/src/rich_click/rich_click.py) can be provided to `feud.run`, e.g.:
+>
+> ```python
+> feud.run(command, SHOW_ARGUMENTS=False)
+> ```
+
 <table>
 <tr>
 <th>

--- a/feud/core/__init__.py
+++ b/feud/core/__init__.py
@@ -27,7 +27,7 @@ from feud.core.group import *
 
 __all__ = ["Group", "compile", "command", "run"]
 
-RICH_SETTINGS_REGEX = r"^[A-Z]+(_[A-Z]+)*$"
+RICH_SETTINGS_REGEX = r"^[A-Z]+(_[A-Z]+)*$"  # screaming snake case
 RICH_DEFAULTS = {"SHOW_ARGUMENTS": True}
 
 
@@ -181,6 +181,21 @@ def rich_styler(
         if RICH:
             # alias click.rich_click
             rich = click.rich_click
+
+            # check for screaming snake case kwargs that are invalid
+            invalid_kwargs: dict[str, t.Any] = {
+                k: rich_kwargs.pop(k)
+                for k in rich_kwargs.copy()
+                if not hasattr(rich, k)
+            }
+
+            # warn if any invalid kwargs
+            if invalid_kwargs:
+                warnings.warn(
+                    "The following invalid rich-click settings will be "
+                    f"ignored: {invalid_kwargs}.",
+                    stacklevel=1,
+                )
 
             # override: true defaults -> feud defaults -> specified settings
             true_defaults = {k: getattr(rich, k) for k in rich_kwargs}

--- a/feud/core/__init__.py
+++ b/feud/core/__init__.py
@@ -7,20 +7,28 @@
 
 from __future__ import annotations
 
+import contextlib
 import inspect
+import re
 import typing as t
-
-import pydantic as pyd
+import warnings
 
 try:
     import rich_click as click
+
+    RICH = True
 except ImportError:
     import click
+
+    RICH = False
 
 from feud.core.command import *
 from feud.core.group import *
 
 __all__ = ["Group", "compile", "command", "run"]
+
+RICH_SETTINGS_REGEX = r"^[A-Z]+(_[A-Z]+)*$"
+RICH_DEFAULTS = {"SHOW_ARGUMENTS": True}
 
 
 def run(
@@ -147,4 +155,56 @@ def run(
     else:
         runner = command(obj)
 
-    return runner(args, **kwargs)
+    # set (and unset) feud/user-specified rich-click settings
+    with rich_styler(kwargs) as runner_kwargs:
+        return runner(args, **runner_kwargs)
+
+
+@contextlib.contextmanager
+def rich_styler(
+    original_kwargs: dict[str, t.Any],
+    /,
+) -> t.Generator[dict[str, t.Any]]:
+    """Temporarily applies Feud and user-specified rich-click settings if
+    rich-click is installed and rich-click keywords were provided to feud.run.
+    """
+    kwargs: dict[str, t.Any] = original_kwargs.copy()
+
+    # get rich_click settings
+    rich_kwargs: dict[str, t.Any] = {
+        k: kwargs.pop(k)
+        for k in original_kwargs
+        if re.match(RICH_SETTINGS_REGEX, k)
+    }
+
+    try:
+        if RICH:
+            # alias click.rich_click
+            rich = click.rich_click
+
+            # override: true defaults -> feud defaults -> specified settings
+            true_defaults = {k: getattr(rich, k) for k in rich_kwargs}
+            rich_kwargs = {**true_defaults, **RICH_DEFAULTS, **rich_kwargs}
+
+            # set rich_click settings
+            for k, v in rich_kwargs.items():
+                setattr(rich, k, v)
+
+            # yield kwargs for the runner
+            yield kwargs
+        else:
+            if rich_kwargs:
+                warnings.warn(
+                    "rich-click settings were provided to feud.run, "
+                    "but rich-click is not installed - these settings "
+                    "will be ignored.",
+                    stacklevel=1,
+                )
+
+            # yield kwargs for the runner
+            yield kwargs
+    finally:
+        # restore rich_click defaults
+        if RICH:
+            for k, v in true_defaults.items():
+                setattr(rich, k, v)


### PR DESCRIPTION
- If `rich-click` is installed, `rich_click.SHOW_ARGUMENTS` is now set to `True` by default, meaning that arguments are displayed in command help.
- Users can now also provide `rich_click` configuration to `feud.run`, e.g.:
  ```python
   feud.run(command, SHOW_ARGUMENTS=False, MAX_WIDTH=50)
   ```