### PR TITLE
feat: add `feud.build` + move `rich_click` styling to `feud.Config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,14 +821,6 @@ Without Rich-formatted output
 </tr>
 </table>
 
-> [!TIP]
->
-> [Settings for `rich-click`](https://github.com/ewels/rich-click/blob/main/src/rich_click/rich_click.py) can be provided to `feud.run`, e.g.:
->
-> ```python
-> feud.run(command, rich_settings={"SHOW_ARGUMENTS": False})
-> ```
-
 ## Build status
 
 | `master`                                                                                                                                                                                       | `dev`                                                                                                                                                                                            |

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,7 +40,7 @@ Feud
 
 ----
 
-Designing a *good* CLI can spiral into chaos without the help of
+Designing a *good* CLI can quickly spiral into chaos without the help of
 an intuitive CLI builder.
 
 **Feud builds on** `Click <https://click.palletsprojects.com/en/8.1.x/>`__ **for

--- a/docs/source/sections/core/group.rst
+++ b/docs/source/sections/core/group.rst
@@ -33,5 +33,4 @@ API reference
     :members:
     :exclude-members: from_dict, from_iter, from_module
 
-.. autofunction:: feud.core.group.compile
     

--- a/docs/source/sections/core/run.rst
+++ b/docs/source/sections/core/run.rst
@@ -1,5 +1,5 @@
-Running commands/groups
-=======================
+Running and building CLIs
+=========================
 
 .. contents:: Table of Contents
     :class: this-will-duplicate-information-and-it-is-still-useful-here
@@ -7,9 +7,14 @@ Running commands/groups
     :backlinks: none
     :depth: 3
 
+- :py:func:`.run`: **Build and run** runnable objects as a :py:class:`click.Command` or :py:class:`click.Group`.
+- :py:func:`.build`: **Build** runnable object(s) into a 
+  :py:class:`click.Command`, :py:class:`click.Group` (or :py:class:`.Group`).
+
 ----
 
 API reference
 -------------
 
-.. autofunction:: feud.core.run
+.. automodule:: feud.core
+    :members: run, build

--- a/feud/_internal/_command.py
+++ b/feud/_internal/_command.py
@@ -12,8 +12,12 @@ import typing as t
 
 try:
     import rich_click as click
+
+    RICH = True
 except ImportError:
     import click
+
+    RICH = False
 
 from feud._internal import _decorators, _inflect, _types
 from feud.config import Config
@@ -56,7 +60,10 @@ class CommandState:
     options: dict[str, ParameterSpec] = dataclasses.field(default_factory=dict)
     description: str | None = None
 
-    def decorate(self: CommandState, func: t.Callable) -> click.Command:
+    def decorate(  # noqa: PLR0915
+        self: CommandState,
+        func: t.Callable,
+    ) -> click.Command:
         meta_vars: dict[str, str] = {}
         sensitive_vars: dict[str, bool] = {}
         positional: list[str] = []
@@ -145,6 +152,14 @@ class CommandState:
 
         if self.pass_context:
             command = click.pass_context(command)
+
+        if RICH:
+            # apply rich-click styling
+            command = click.rich_config(
+                help_config=click.RichHelpConfiguration(
+                    **self.config.rich_click_kwargs
+                )
+            )(command)
 
         constructor = click.group if self.is_group else click.command
         command = constructor(**self.click_kwargs)(command)

--- a/feud/_internal/_decorators.py
+++ b/feud/_internal/_decorators.py
@@ -13,10 +13,7 @@ import typing as t
 import pydantic as pyd
 import pydantic_core as pydc
 
-try:
-    import rich_click as click
-except ImportError:
-    import click
+from feud import click
 
 
 def validate_call(

--- a/feud/_internal/_metaclass.py
+++ b/feud/_internal/_metaclass.py
@@ -8,14 +8,10 @@ from __future__ import annotations
 import abc
 import typing as t
 
+from feud import click
 from feud._internal import _command
 from feud.config import Config
 from feud.core.command import command
-
-try:
-    import rich_click as click
-except ImportError:
-    import click
 
 
 class GroupBase(abc.ABCMeta):

--- a/feud/config.py
+++ b/feud/config.py
@@ -44,6 +44,13 @@ class Config(pyd.BaseModel):
     #: :py:func:`pydantic.validate_call_decorator.validate_call`.
     pydantic_kwargs: dict[str, Any] = {}
 
+    #: Styling settings for ``rich-click``.
+    #:
+    #: See all available options
+    #: `here <https://github.com/ewels/rich-click/blob/e6a3add46c591d49079d440917700dfe28cf0cfe/src/rich_click/rich_help_configuration.py#L50>`__
+    #: (as of ``rich-click`` v1.7.2).
+    rich_click_kwargs: dict[str, Any] = {"show_arguments": True}
+
     def __init__(self: Config, **kwargs: Any) -> Config:
         caller: str = inspect.currentframe().f_back.f_code.co_name
         if caller != Config._create.__name__:
@@ -73,6 +80,7 @@ def config(
     show_help_datetime_formats: bool | None = None,
     show_help_envvars: bool | None = None,
     pydantic_kwargs: dict[str, Any] | None = None,
+    rich_click_kwargs: dict[str, Any] | None = None,
 ) -> Config:
     """Create a reusable configuration for :py:func:`.command` or
     :py:class:`.Group` objects.
@@ -96,6 +104,13 @@ def config(
     pydantic_kwargs:
         Validation settings for
         :py:func:`pydantic.validate_call_decorator.validate_call`.
+
+    rich_click_kwargs:
+        Styling settings for ``rich-click``.
+
+        See all available options
+        `here <https://github.com/ewels/rich-click/blob/e6a3add46c591d49079d440917700dfe28cf0cfe/src/rich_click/rich_help_configuration.py#L50>`__
+        (as of ``rich-click`` v1.7.2).
 
     Returns
     -------
@@ -132,4 +147,5 @@ def config(
         show_help_datetime_formats=show_help_datetime_formats,
         show_help_envvars=show_help_envvars,
         pydantic_kwargs=pydantic_kwargs,
+        rich_click_kwargs=rich_click_kwargs,
     )

--- a/feud/core/__init__.py
+++ b/feud/core/__init__.py
@@ -7,30 +7,19 @@
 
 from __future__ import annotations
 
-import contextlib
 import inspect
 import sys
 import types
 import typing as t
 import warnings
 
-try:
-    import rich_click as click
-
-    RICH = True
-except ImportError:
-    import click
-
-    RICH = False
-
 import feud.exceptions
+from feud import click
 from feud.config import Config
 from feud.core.command import *
 from feud.core.group import *
 
-__all__ = ["Group", "compile", "command", "run"]
-
-RICH_DEFAULTS = {"SHOW_ARGUMENTS": True}
+__all__ = ["Group", "build", "command", "run"]
 
 Runner = t.Union[
     click.Command,
@@ -54,13 +43,10 @@ def run(
     help: str | None = None,  # noqa: A002
     epilog: str | None = None,
     config: Config | None = None,
-    rich_settings: dict[str, t.Any] | None = None,
     warn: bool = True,
     **click_kwargs: t.Any,
 ) -> t.Any:
-    """
-
-    Run a function, :py:class:`click.Command`, :py:class:`.Group`,
+    """Run a function, :py:class:`click.Command`, :py:class:`.Group`,
     or :py:class:`click.Group`.
 
     Multiple functions/commands can also be provided as a :py:obj:`dict`,
@@ -106,14 +92,6 @@ def run(
         If a :py:obj:`dict`, iterable or module ``obj`` is provided, the
         configuration will be forwarded to the nested runnable objects within.
 
-    rich_settings:
-        Styling options for ``rich-click``, e.g.
-        ``{"SHOW_ARGUMENTS": False, "MAX_WIDTH": 60}``.
-
-        See all available options
-        `here <https://github.com/ewels/rich-click/blob/e6a3add46c591d49079d440917700dfe28cf0cfe/src/rich_click/rich_click.py#L48-L131>`__
-        (as of ``rich-click`` v1.7.2).
-
     warn:
         Silences warnings that are produced if ``name``, ``help``, ``epilog``
         or ``config`` are provided when ``obj`` is a :py:class:`click.Command`,
@@ -126,11 +104,6 @@ def run(
     Returns
     -------
     Output of the called object.
-
-    Raises
-    ------
-    feud.exceptions.CompilationError
-        If no runnable object or current module can be determined.
 
     Examples
     --------
@@ -167,7 +140,7 @@ def run(
     >>> class CLI(feud.Group):
     ...     def func(*, opt: int) -> int:
     ...         return opt
-    >>> group: click.Group = feud.compile(CLI)
+    >>> group: click.Group = CLI.compile()
     >>> feud.run(group, ["func", "--opt", "3"], standalone_mode=False)
     3
 
@@ -222,20 +195,8 @@ def run(
         args = obj
         obj = None
 
-    # use current module if no runner provided
-    if obj is None:
-        frame = inspect.stack()[1]
-        obj = inspect.getmodule(frame[0]) or sys.modules.get("__main__")
-
-    if obj is None:
-        msg = (
-            "Unable to build command - no runnable object was provided "
-            "and no current module can be determined in the present context."
-        )
-        raise feud.CompilationError(msg)
-
     # get runner
-    runner: click.Command | type[Group] = get_runner(
+    runner: click.Command | click.Group = build(
         obj,
         name=name,
         help=help,
@@ -244,13 +205,12 @@ def run(
         warn=warn,
     )
 
-    # set (and unset) feud/user-specified rich-click settings
-    with rich_styler(rich_settings or {}):
-        return runner(args, **click_kwargs)
+    return runner(args, **click_kwargs)
 
 
 def get_runner(
     obj: Runner,
+    /,
     *,
     name: str | None = None,
     help: str | None = None,  # noqa: A002
@@ -355,56 +315,103 @@ def get_runner(
     return obj
 
 
-@contextlib.contextmanager
-def rich_styler(
-    kwargs: dict[str, t.Any] | None,
+def build(
+    obj: Runner | None = None,
     /,
-) -> t.Generator[dict[str, t.Any]]:
-    """Temporarily applies Feud and user-specified rich-click settings if
-    rich-click is installed and rich-click keywords were provided to feud.run.
+    *,
+    name: str | None = None,
+    help: str | None = None,  # noqa: A002
+    epilog: str | None = None,
+    config: Config | None = None,
+    warn: bool = True,
+    compile: bool = True,  # noqa: A002
+) -> click.Command | click.Group | Group:
+    """Build a :py:class:`click.Command` or :py:class:`click.Group` from
+    a runnable object.
+
+    See :py:func:`.run` for details on runnable objects.
+
+    .. warning::
+
+        ``name``, ``help``, ``epilog`` and ``config`` are ignored if a
+        :py:class:`click.Command`, :py:class:`click.Group` or
+        :py:class:`.Group` is provided.
+
+    Parameters
+    ----------
+    obj:
+        Runnable group, command or function to run, or :py:obj:`dict`,
+        iterable or module of runnable objects.
+
+    name:
+        CLI command or group name.
+
+    help:
+        CLI command or group description, displayed when ``--help``
+        is called. If not set, the docstring of the object will be used if
+        available.
+
+    epilog:
+        CLI command or group epilog. Appears at the bottom of ``--help``.
+
+    config:
+        Configuration for the command or group.
+
+        If a :py:obj:`dict`, iterable or module ``obj`` is provided, the
+        configuration will be forwarded to the nested runnable objects within.
+
+    warn:
+        Silences warnings that are produced if ``name``, ``help``, ``epilog``
+        or ``config`` are provided when ``obj`` is a :py:class:`click.Command`,
+        :py:class:`click.Group` or :py:class:`.Group`.
+
+    compile:
+        Whether or not to compile :py:class:`.Group` objects into
+        :py:class:`click.Group` objects.
+
+    Returns
+    -------
+    :py:class:`click.Command`, :py:class:`click.Group` or :py:class:`.Group`
+
+    Raises
+    ------
+    feud.exceptions.CompilationError
+        If no runnable object or current module can be determined.
+
+    Examples
+    --------
+    >>> import feud
+    >>> from feud import click
+    >>> def func1(*, opt: int) -> int:
+    ...     return opt
+    >>> def func2(*, opt: float) -> float:
+    ...     return opt
+    >>> group: click.Group = feud.build([func1, func2])
+    >>> isinstance(group, click.Group)
+    True
     """
-    # avoid mutating
-    kwargs: dict[str, t.Any] = kwargs.copy()
+    # use current module if no runner provided
+    if obj is None:
+        frame = inspect.stack()[1]
+        obj = inspect.getmodule(frame[0]) or sys.modules.get("__main__")
 
-    try:
-        if RICH:
-            # alias click.rich_click
-            rich = click.rich_click
+    if obj is None:
+        msg = (
+            "Unable to build command - no runnable object was provided "
+            "and no current module can be determined in the present context."
+        )
+        raise feud.CompilationError(msg)
 
-            # check for screaming snake case kwargs that are invalid
-            invalid_kwargs: dict[str, t.Any] = {
-                k: kwargs.pop(k) for k in kwargs.copy() if not hasattr(rich, k)
-            }
+    runner: click.Command | Group = get_runner(
+        obj,
+        name=name,
+        help=help,
+        epilog=epilog,
+        config=config,
+        warn=warn,
+    )
 
-            # warn if any invalid kwargs
-            if invalid_kwargs:
-                msg = (
-                    "The following invalid rich-click settings will be "
-                    f"ignored: {invalid_kwargs}."
-                )
-                warnings.warn(msg, stacklevel=1)
+    if compile and inspect.isclass(runner) and issubclass(runner, Group):
+        return runner.compile()
 
-            # override: true defaults -> feud defaults -> specified settings
-            true_defaults = {k: getattr(rich, k) for k in kwargs}
-            kwargs = {**true_defaults, **RICH_DEFAULTS, **kwargs}
-
-            # set rich_click settings
-            for k, v in kwargs.items():
-                setattr(rich, k, v)
-
-            yield
-        else:
-            if kwargs:
-                msg = (
-                    "rich-click settings were provided to feud.run, "
-                    "but rich-click is not installed - these settings "
-                    "will be ignored."
-                )
-                warnings.warn(msg, stacklevel=1)
-
-            yield
-    finally:
-        # restore rich_click defaults
-        if RICH:
-            for k, v in true_defaults.items():
-                setattr(rich, k, v)
+    return runner

--- a/feud/core/command.py
+++ b/feud/core/command.py
@@ -40,6 +40,7 @@ def command(
     show_help_datetime_formats: bool | None = None,
     show_help_envvars: bool | None = None,
     pydantic_kwargs: dict[str, typing.Any] | None = None,
+    rich_click_kwargs: dict[str, typing.Any] | None = None,
     config: Config | None = None,
     **click_kwargs: typing.Any,
 ) -> click.Command:
@@ -67,6 +68,13 @@ def command(
     pydantic_kwargs:
         Validation settings for
         :py:func:`pydantic.validate_call_decorator.validate_call`.
+
+    rich_click_kwargs:
+        Styling settings for ``rich-click``.
+
+        See all available options
+        `here <https://github.com/ewels/rich-click/blob/e6a3add46c591d49079d440917700dfe28cf0cfe/src/rich_click/rich_help_configuration.py#L50>`__
+        (as of ``rich-click`` v1.7.2).
 
     config:
         Configuration for the command.
@@ -112,6 +120,7 @@ def command(
             show_help_datetime_formats=show_help_datetime_formats,
             show_help_envvars=show_help_envvars,
             pydantic_kwargs=pydantic_kwargs,
+            rich_click_kwargs=rich_click_kwargs,
         )
         # decorate function
         return get_command(__func, config=cfg, click_kwargs=click_kwargs)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -16,6 +16,7 @@ def test_create_no_base_no_kwargs() -> None:
     assert config.show_help_datetime_formats is False
     assert config.show_help_envvars is True
     assert config.pydantic_kwargs == {}
+    assert config.rich_click_kwargs == {"show_arguments": True}
 
 
 def test_create_no_base_none_kwargs() -> None:
@@ -32,6 +33,7 @@ def test_create_no_base_none_kwargs() -> None:
     assert config.show_help_datetime_formats is False
     assert config.show_help_envvars is True
     assert config.pydantic_kwargs == {}
+    assert config.rich_click_kwargs == {"show_arguments": True}
 
 
 def test_create_no_base_with_kwargs_default() -> None:

--- a/tests/unit/test_core/fixtures/module.py
+++ b/tests/unit/test_core/fixtures/module.py
@@ -64,13 +64,11 @@ class Subgroup(feud.Group, name="feud-subgroup"):
 
 Group.register(Subgroup)
 
-click_group: click.Group = feud.compile(
-    types.new_class(
-        "ClickGroup",
-        bases=(Group,),
-        kwds={
-            "name": "click-group",
-            "help": "This is a Click group.",
-        },
-    )
-)
+click_group: click.Group = types.new_class(
+    "ClickGroup",
+    bases=(Group,),
+    kwds={
+        "name": "click-group",
+        "help": "This is a Click group.",
+    },
+).compile()

--- a/tests/unit/test_core/test_group.py
+++ b/tests/unit/test_core/test_group.py
@@ -72,7 +72,7 @@ def test_compile() -> None:
         def g(*, arg1: int, arg2: bool) -> None:
             pass
 
-    group = feud.compile(Test)
+    group = Test.compile()
     assert isinstance(group, click.Group)
 
     assert len(group.commands) == 2
@@ -169,7 +169,7 @@ def test_config_kwarg_propagation() -> None:
         def g(*, arg1: int = 2, arg2: bool = False) -> None:
             pass
 
-    group = feud.compile(Test)
+    group = Test.compile()
     for command in group.commands.values():
         for param in command.params:
             assert param.show_default is False
@@ -181,7 +181,7 @@ def test_config_kwarg_propagation() -> None:
         def g(*, arg1: int = 2, arg2: bool = False) -> None:
             pass
 
-    group = feud.compile(Test)
+    group = Test.compile()
     for command in group.commands.values():
         for param in command.params:
             assert param.show_default is True
@@ -195,7 +195,7 @@ def test_config_propagation() -> None:
         def g(*, arg1: int = 2, arg2: bool = False) -> None:
             pass
 
-    group = feud.compile(Test)
+    group = Test.compile()
     for command in group.commands.values():
         for param in command.params:
             assert param.show_default is False
@@ -207,7 +207,7 @@ def test_config_propagation() -> None:
         def g(*, arg1: int = 2, arg2: bool = False) -> None:
             pass
 
-    group = feud.compile(Test)
+    group = Test.compile()
     for command in group.commands.values():
         for param in command.params:
             assert param.show_default is True
@@ -219,7 +219,7 @@ def test_config_kwarg_override() -> None:
         def f(*, arg1: int = 1) -> None:
             pass
 
-    group = feud.compile(Test)
+    group = Test.compile()
     for command in group.commands.values():
         for param in command.params:
             assert param.show_default is True
@@ -244,7 +244,7 @@ def test_subgroups_parent_single_child() -> None:
     assert Parent.subgroups() == [Child]
     assert Child.subgroups() == []
 
-    parent = feud.compile(Parent)
+    parent = Parent.compile()
     f, child = itemgetter("f", "child")(parent.commands)
 
     assert isinstance(f, click.Command)
@@ -293,7 +293,7 @@ def test_subgroups_parent_multi_children() -> None:
     assert Child1.subgroups() == []
     assert Child2.subgroups() == []
 
-    parent = feud.compile(Parent)
+    parent = Parent.compile()
     f, child1, child2 = itemgetter("f", "child1", "child2")(parent.commands)
 
     assert isinstance(f, click.Command)
@@ -409,7 +409,7 @@ def test_subgroups_nested() -> None:
     assert Child3.subgroups() == []
     assert Child4.subgroups() == []
 
-    parent = feud.compile(Parent)
+    parent = Parent.compile()
 
     assert len(parent.commands) == 3
     f, child1, child2 = itemgetter("f", "child1", "child2")(parent.commands)
@@ -519,7 +519,7 @@ def test_deregister_nested() -> None:
     assert Child1.subgroups() == [Child2]
     assert Child2.subgroups() == [Child3]
 
-    parent = feud.compile(Parent)
+    parent = Parent.compile()
 
     assert len(parent.commands) == 3
     f, child1, child2 = itemgetter("f", "child1", "child2")(parent.commands)
@@ -573,7 +573,7 @@ def test_deregister_nested() -> None:
     assert Child1.subgroups() == [Child2]
     assert Child2.subgroups() == []
 
-    parent = feud.compile(Parent)
+    parent = Parent.compile()
 
     assert len(parent.commands) == 3
     f, child1, child2 = itemgetter("f", "child1", "child2")(parent.commands)
@@ -673,7 +673,7 @@ def test_inheritance_ancestor() -> None:
         def f(*, arg: int) -> int:
             return arg
 
-    grandparent = feud.compile(Grandparent)
+    grandparent = Grandparent.compile()
     assert grandparent.name == "older"
     assert list(grandparent.commands) == ["f"]
 
@@ -681,7 +681,7 @@ def test_inheritance_ancestor() -> None:
         def g(*, arg: int) -> int:
             return arg
 
-    parent = feud.compile(Parent)
+    parent = Parent.compile()
     assert parent.name == "old"
     assert list(parent.commands) == ["f", "g"]
     assert all(
@@ -693,7 +693,7 @@ def test_inheritance_ancestor() -> None:
         def h(*, arg: int) -> int:
             return arg
 
-    child = feud.compile(Child)
+    child = Child.compile()
     assert child.name == "young"
     assert list(child.commands) == ["f", "g", "h"]
     assert all(
@@ -714,7 +714,7 @@ def test_inheritance_multiple() -> None:
         def f(*, arg: int) -> int:
             return arg
 
-    mother = feud.compile(Mother)
+    mother = Mother.compile()
     assert mother.name == "mother"
     assert list(mother.commands) == ["f"]
 
@@ -724,7 +724,7 @@ def test_inheritance_multiple() -> None:
         def g(*, arg: int) -> int:
             return arg
 
-    father = feud.compile(Father)
+    father = Father.compile()
     assert father.name == "father"
     assert list(father.commands) == ["g"]
 
@@ -732,7 +732,7 @@ def test_inheritance_multiple() -> None:
         def h(*, arg: int) -> int:
             return arg
 
-    child = feud.compile(Child)
+    child = Child.compile()
     assert list(child.commands) == ["f", "g", "h"]
     assert Child.__feud_config__ == feud.config(
         negate_flags=False,
@@ -748,7 +748,7 @@ def test_inheritance_multiple() -> None:
         def h(*, arg: int) -> int:
             return arg
 
-    child = feud.compile(Child)
+    child = Child.compile()
     assert list(child.commands) == ["g", "f", "h"]
     assert Child.__feud_config__ == feud.config(
         negate_flags=False,
@@ -796,29 +796,29 @@ def test_register_deregister_compile() -> None:
     class Child(Parent):
         pass
 
-    child = feud.compile(Child)
+    child = Child.compile()
     assert list(child.commands) == ["f", "subgroup"]
 
     Child.deregister(Subgroup)
 
-    child = feud.compile(Child)
+    child = Child.compile()
     assert list(child.commands) == ["f"]
 
     class Child(Parent):
         pass
 
-    parent = feud.compile(Parent)
+    parent = Parent.compile()
     assert list(parent.commands) == ["f", "subgroup"]
 
-    child = feud.compile(Child)
+    child = Child.compile()
     assert list(child.commands) == ["f", "subgroup"]
 
     Parent.deregister(Subgroup)
 
-    parent = feud.compile(Parent)
+    parent = Parent.compile()
     assert list(parent.commands) == ["f"]
 
-    child = feud.compile(Child)
+    child = Child.compile()
     assert list(child.commands) == ["f", "subgroup"]
 
 
@@ -1201,7 +1201,7 @@ def test_main(capsys: pytest.CaptureFixture) -> None:
             """
             return ctx.obj["root"] / path
 
-    group = feud.compile(Test)
+    group = Test.compile()
 
     assert_help(
         group,
@@ -1268,7 +1268,7 @@ def test_main_inheritance_no_docstring(capsys: pytest.CaptureFixture) -> None:
     class Child(Test):
         pass
 
-    group = feud.compile(Child)
+    group = Child.compile()
 
     assert_help(
         group,
@@ -1341,7 +1341,7 @@ def test_main_inheritance_docstring(capsys: pytest.CaptureFixture) -> None:
             Root directory
         """
 
-    group = feud.compile(Child)
+    group = Child.compile()
 
     assert_help(
         group,

--- a/tests/unit/test_internal/test_docstring.py
+++ b/tests/unit/test_internal/test_docstring.py
@@ -178,14 +178,14 @@ def test_get_description_class_single_line_no_doc() -> None:
     class Group(feud.Group):
         pass
 
-    assert feud.compile(Group).help is None
+    assert Group.compile().help is None
 
 
 def test_get_description_class_single_line_doc() -> None:
     class Group(feud.Group):
         """Line 1."""
 
-    assert feud.compile(Group).help == "Line 1."
+    assert Group.compile().help == "Line 1."
 
 
 def test_get_description_class_single_line_doc_with_examples() -> None:
@@ -197,7 +197,7 @@ def test_get_description_class_single_line_doc_with_examples() -> None:
         >>> # Hello World!
         """
 
-    assert feud.compile(Group).help == "Line 1."
+    assert Group.compile().help == "Line 1."
 
 
 def test_get_description_class_multi_line_doc() -> None:
@@ -207,7 +207,7 @@ def test_get_description_class_multi_line_doc() -> None:
         Line 2.
         """
 
-    assert feud.compile(Group).help == "Line 1.\n\nLine 2."
+    assert Group.compile().help == "Line 1.\n\nLine 2."
 
 
 def test_get_description_class_multi_line_doc_with_examples() -> None:
@@ -221,7 +221,7 @@ def test_get_description_class_multi_line_doc_with_examples() -> None:
         >>> # Hello World!
         """
 
-    assert feud.compile(Group).help == "Line 1.\n\nLine 2."
+    assert Group.compile().help == "Line 1.\n\nLine 2."
 
 
 def test_get_description_class_multi_line_doc_with_f() -> None:
@@ -231,7 +231,7 @@ def test_get_description_class_multi_line_doc_with_f() -> None:
         Line 2.\f
         """
 
-    assert feud.compile(Group).help == "Line 1.\n\nLine 2."
+    assert Group.compile().help == "Line 1.\n\nLine 2."
 
 
 def test_get_description_class_multi_line_doc_with_examples_and_f() -> None:
@@ -245,7 +245,7 @@ def test_get_description_class_multi_line_doc_with_examples_and_f() -> None:
         >>> # Hello World!
         """
 
-    assert feud.compile(Group).help == "Line 1.\n\nLine 2."
+    assert Group.compile().help == "Line 1.\n\nLine 2."
 
 
 def test_get_description_class_main() -> None:
@@ -260,7 +260,7 @@ def test_get_description_class_main() -> None:
             >>> # Hello World!
             """
 
-    assert feud.compile(Group).help == "Line 1.\n\nLine 2."
+    assert Group.compile().help == "Line 1.\n\nLine 2."
 
 
 def test_get_description_class_override() -> None:
@@ -274,4 +274,4 @@ def test_get_description_class_override() -> None:
         >>> # Hello World!
         """
 
-    assert feud.compile(Group).help == "Override."
+    assert Group.compile().help == "Override."

--- a/tests/unit/test_internal/test_metaclass.py
+++ b/tests/unit/test_internal/test_metaclass.py
@@ -86,7 +86,7 @@ def test_metaclass_click_kwargs() -> None:
     assert Test.__feud_config__ == feud.config()
     assert Test.__feud_click_kwargs__ == {"name": name, "epilog": epilog}
 
-    group = feud.compile(Test)
+    group = Test.compile()
     assert group.name == name
     assert group.epilog == epilog
 
@@ -115,7 +115,7 @@ def test_metaclass_config_with_feud_kwargs_and_click_kwargs() -> None:
     assert Test.__feud_config__ == feud.config(negate_flags=True)
     assert Test.__feud_click_kwargs__ == {"name": name, "epilog": epilog}
 
-    group = feud.compile(Test)
+    group = Test.compile()
     assert group.name == name
     assert group.epilog == epilog
 


### PR DESCRIPTION
- Change `feud.compile(Group)` to `Group.compile()`
- Add `feud.build` to produce `click.Command`/`click.Group` objects.
- Remove `rich_styler` context manager and add new `rich_click_kwargs` field to `feud.Config`.