### PR TITLE
docs: specify virtual env location in `.readthedocs.yaml`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,10 +5,11 @@ build:
   tools:
     python: "3.11"
   jobs:
-    post_install:
+    post_create_environment:
       - pip install poetry
       - poetry config virtualenvs.create false
-      - poetry install --only base,main,docs
+    post_install:
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --only base,main,docs
 
 sphinx:
   configuration: docs/source/conf.py

--- a/README.md
+++ b/README.md
@@ -46,9 +46,6 @@
 
 ## About
 
-> [!WARNING]  
-> _Writing command-line interfaces can get messy!_
-
 Designing a _good_ CLI can quickly spiral into chaos without the help of
 an intuitive CLI framework.
 


### PR DESCRIPTION
## Description

**Specify Poetry virtual environment via environment variable in `.readthedocs.yaml`**

(was breaking Sphinx documentation builds, which now uses Poetry >1.8)

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
