### PR TITLE
chore(deps): update `pydantic_extra_types` supported types

### DIFF
--- a/docs/source/sections/typing/pydantic_extra_types.rst
+++ b/docs/source/sections/typing/pydantic_extra_types.rst
@@ -62,6 +62,22 @@ Country types
 - :py:obj:`pydantic_extra_types.country.CountryOfficialName` (``>= 2.1.0, <2.4.0``)
 - :py:obj:`pydantic_extra_types.country.CountryShortName` (``>= 2.1.0``)
 
+ISBN type
+---------
+
+- :py:obj:`pydantic_extra_types.isbn.ISBN` (``>= 2.4.0``)
+
+Language types
+--------------
+
+- :py:obj:`pydantic_extra_types.language_code.LanguageAlpha2` (``>= 2.7.0``)
+- :py:obj:`pydantic_extra_types.language_code.LanguageName` (``>= 2.7.0``)
+
+MAC address type
+----------------
+
+- :py:obj:`pydantic_extra_types.mac_address.MacAddress` (``>= 2.1.0``)
+
 Phone number type
 -----------------
 
@@ -73,15 +89,15 @@ Payment types
 - :py:obj:`pydantic_extra_types.payment.PaymentCardBrand` (``>= 2.1.0``)
 - :py:obj:`pydantic_extra_types.payment.PaymentCardNumber` (``>= 2.1.0``)
 
-MAC address type
-----------------
-
-- :py:obj:`pydantic_extra_types.mac_address.MacAddress` (``>= 2.1.0``)
-
 Routing number type
 -------------------
 
 - :py:obj:`pydantic_extra_types.routing_number.ABARoutingNumber` (``>= 2.1.0``)
+
+Semantic version type
+---------------------
+
+- :py:obj:`pydantic_extra_types.semantic_version.SemanticVersion` (``>= 2.9.0``)
 
 ULID type
 ---------

--- a/feud/_internal/_types/click.py
+++ b/feud/_internal/_types/click.py
@@ -111,6 +111,26 @@ try:
         from pydantic_extra_types.country import CountryOfficialName
 
         EXTRA_TYPES[CountryOfficialName] = click.STRING
+
+    if version >= packaging.version.parse("2.4.0"):
+        from pydantic_extra_types.isbn import ISBN
+
+        EXTRA_TYPES[ISBN] = click.STRING
+
+    if version >= packaging.version.parse("2.7.0"):
+        from pydantic_extra_types.language_code import (
+            LanguageAlpha2,
+            LanguageName,
+        )
+
+        EXTRA_TYPES[LanguageAlpha2] = click.STRING
+        EXTRA_TYPES[LanguageName] = click.STRING
+
+    if version >= packaging.version.parse("2.9.0"):
+        from pydantic_extra_types.semantic_version import SemanticVersion
+
+        EXTRA_TYPES[SemanticVersion] = click.STRING
+
 except ImportError:
     EXTRA_TYPES = {}
 

--- a/feud/typing/pydantic_extra_types.py
+++ b/feud/typing/pydantic_extra_types.py
@@ -65,6 +65,25 @@ try:
     if version >= packaging.version.parse("2.2.0"):
         from pydantic_extra_types.ulid import ULID
 
-        __all__.extend(["ULID"])
+        __all__.append("ULID")
+
+    if version >= packaging.version.parse("2.4.0"):
+        from pydantic_extra_types.isbn import ISBN
+
+        __all__.append("ISBN")
+
+    if version >= packaging.version.parse("2.7.0"):
+        from pydantic_extra_types.language_code import (
+            LanguageAlpha2,
+            LanguageName,
+        )
+
+        __all__.extend(["LanguageAlpha2", "LanguageName"])
+
+    if version >= packaging.version.parse("2.9.0"):
+        from pydantic_extra_types.semantic_version import SemanticVersion
+
+        __all__.append("SemanticVersion")
+
 except ImportError:
     pass

--- a/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_pydantic_extra_types.py
+++ b/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_pydantic_extra_types.py
@@ -34,6 +34,11 @@ from feud.config import Config
         ),
         (t.PhoneNumber, click.STRING),
         (t.ABARoutingNumber, click.STRING),
+        (t.ULID, click.STRING),
+        (t.ISBN, click.STRING),
+        (t.LanguageAlpha2, click.STRING),
+        (t.LanguageName, click.STRING),
+        (t.SemanticVersion, click.STRING),
     ],
 )
 def test_pydantic_extra(


### PR DESCRIPTION
## Updated supported `pydantic_extra_types`

Adds support for:
- `ISBN`
- `LanguageAlpha2` and `LanguageName`
- `SemanticVersion`

Adds missing unit test for the `ULID` type.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
