### PR TITLE
chore(pkg): use `typing.Self` annotation

### DIFF
--- a/feud/_internal/_command.py
+++ b/feud/_internal/_command.py
@@ -57,7 +57,7 @@ class CommandState:
     description: str | None = None
 
     def decorate(  # noqa: PLR0915
-        self: CommandState,
+        self: t.Self,
         func: t.Callable,
     ) -> click.Command:
         meta_vars: dict[str, str] = {}
@@ -164,7 +164,7 @@ class CommandState:
 
         return command
 
-    def get_meta_var(self: CommandState, param: click.Parameter) -> str:
+    def get_meta_var(self: t.Self, param: click.Parameter) -> str:
         match param:
             case click.Argument():
                 return param.make_metavar()

--- a/feud/_internal/_types/click.py
+++ b/feud/_internal/_types/click.py
@@ -131,7 +131,7 @@ AnnotatedArgDict = t.Dict[int, t.Any]
 
 class DateTime(click.DateTime):
     def __init__(
-        self: DateTime,
+        self: t.Self,
         *args: t.Any,
         datetime_type: type,
         show_default_format: bool,
@@ -143,7 +143,7 @@ class DateTime(click.DateTime):
         super().__init__(*args, **kwargs)
 
     def get_metavar(
-        self: DateTime,
+        self: t.Self,
         param: click.Parameter,  # noqa: ARG002
     ) -> str:
         return (
@@ -153,7 +153,7 @@ class DateTime(click.DateTime):
         )
 
     def _try_to_convert_date(
-        self: DateTime,
+        self: t.Self,
         value: t.Any,
         format: str,  # noqa: A002, ARG002
     ) -> t.Any | None:
@@ -165,7 +165,7 @@ class DateTime(click.DateTime):
 
 class Union(click.ParamType):
     def __init__(
-        self: DateTime,
+        self: t.Self,
         *args: t.Any,
         types: list[click.ParamType],
         **kwargs: t.Any,
@@ -182,7 +182,7 @@ class Union(click.ParamType):
             return click_type.get_metavar(param) or click_type.name.upper()
         return None
 
-    def get_metavar(self: DateTime, param: click.Parameter) -> str:
+    def get_metavar(self: t.Self, param: click.Parameter) -> str:
         metavars = [
             metavar
             for click_type in self.types

--- a/feud/config.py
+++ b/feud/config.py
@@ -10,7 +10,7 @@ groups using :py:class:`.Group`.
 from __future__ import annotations
 
 import inspect
-from typing import Any
+import typing as t
 
 import pydantic as pyd
 
@@ -42,16 +42,16 @@ class Config(pyd.BaseModel):
 
     #: Validation settings for
     #: :py:func:`pydantic.validate_call_decorator.validate_call`.
-    pydantic_kwargs: dict[str, Any] = {}
+    pydantic_kwargs: dict[str, t.Any] = {}
 
     #: Styling settings for ``rich-click``.
     #:
     #: See all available options
     #: `here <https://github.com/ewels/rich-click/blob/e6a3add46c591d49079d440917700dfe28cf0cfe/src/rich_click/rich_help_configuration.py#L50>`__
     #: (as of ``rich-click`` v1.7.2).
-    rich_click_kwargs: dict[str, Any] = {"show_arguments": True}
+    rich_click_kwargs: dict[str, t.Any] = {"show_arguments": True}
 
-    def __init__(self: Config, **kwargs: Any) -> Config:
+    def __init__(self: t.Self, **kwargs: t.Any) -> None:
         caller: str = inspect.currentframe().f_back.f_code.co_name
         if caller != Config._create.__name__:
             msg = (
@@ -63,11 +63,11 @@ class Config(pyd.BaseModel):
 
     @classmethod
     def _create(
-        cls: type[Config], base: Config | None = None, **kwargs: Any
+        cls: type[Config], base: Config | None = None, **kwargs: t.Any
     ) -> Config:
         config_kwargs = base.model_dump(exclude_unset=True) if base else {}
         for field in cls.model_fields:
-            value: Any | None = kwargs.get(field)
+            value: t.Any | None = kwargs.get(field)
             if value is not None:
                 config_kwargs[field] = value
         return cls(**config_kwargs)
@@ -79,8 +79,8 @@ def config(
     show_help_defaults: bool | None = None,
     show_help_datetime_formats: bool | None = None,
     show_help_envvars: bool | None = None,
-    pydantic_kwargs: dict[str, Any] | None = None,
-    rich_click_kwargs: dict[str, Any] | None = None,
+    pydantic_kwargs: dict[str, t.Any] | None = None,
+    rich_click_kwargs: dict[str, t.Any] | None = None,
 ) -> Config:
     """Create a reusable configuration for :py:func:`.command` or
     :py:class:`.Group` objects.


### PR DESCRIPTION
## Description

Use `typing.Self` type annotation instead of forward references for `self`.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
