### PR TITLE
feat: add `Group.add_commands`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ build-backend = 'poetry.core.masonry.api'
 
 [tool.poetry.dependencies]
 python = "^3.11"
+packaging = "^24.0"
 pydantic = "^2.0.3"
 click = "^8.1.0"
 docstring-parser = "^0.15"


### PR DESCRIPTION
## Description

Implements #135 to support dynamic addition of commands to groups.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
