### PR TITLE
docs: remove references to `feud.wiki`

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,7 +817,7 @@ Without Rich-formatted output
 
 ## Documentation
 
-- [API reference](https://docs.feud.wiki):
+- [API reference](https://feud.readthedocs.io):
   Library documentation for public modules, classes and functions.
 
 <!--

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Build powerful CLIs with simple idiomatic Python, driven by type 
 readme = "README.md"
 homepage = "https://github.com/eonu/feud"
 repository = "https://github.com/eonu/feud"
-documentation = "https://docs.feud.wiki"
+documentation = "https://feud.readthedocs.io"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",


### PR DESCRIPTION
## Remove references to `feud.wiki`

Domain no longer in use.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
