### PR TITLE
docs: fix `@feud.rename` docs example typo

### DIFF
--- a/docs/source/sections/decorators/rename.rst
+++ b/docs/source/sections/decorators/rename.rst
@@ -81,7 +81,7 @@ We can use the :py:func:`.rename` decorator to rename both the command and param
         to:
             Ending number.
         """
-        print(sum(range(from, to + 1)))
+        print(sum(range(from_, to + 1)))
 
     if __name__ == "__main__":
         feud.run(sum_)


### PR DESCRIPTION
## Fix `@feud.rename` docs example typo

Using wrong variable name.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
