### PR TITLE
feat: support python v3.13, add `mise.toml`, remove `doctest`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,10 @@ jobs:
       - python/install-packages:
           pkg-manager: poetry
           args: --only base
-      - run:
-          name: Docstring tests
-          command: |
-            poetry run tox -e tests.doctest
+      # - run:
+      #     name: Docstring tests
+      #     command: |
+      #       poetry run tox -e tests.doctest
       - run:
           name: Unit tests
           command: |
@@ -46,7 +46,7 @@ jobs:
       name: python/default
     steps:
       - coveralls/upload:
-          carryforward: 3.11, 3.12
+          carryforward: 3.11, 3.12, 3.13
           parallel_finished: true
 
 workflows:
@@ -56,7 +56,7 @@ workflows:
       - tests:
           matrix:
             parameters:
-              version: ["3.11", "3.12"]
+              version: ["3.11", "3.12", "3.13"]
       - coverage:
           requires:
             - tests

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -50,6 +50,6 @@ We are thankful for their work and all the communities who have paved the way wi
 ---
 
 <p align="center">
-  <b>Feud</b> &copy; 2023-2025, Edwin Onuonga - Released under the <a href="https://opensource.org/licenses/MIT">MIT</a> license.<br/>
+  <b>Feud</b> &copy; 2023, Edwin Onuonga - Released under the <a href="https://opensource.org/licenses/MIT">MIT</a> license.<br/>
   <em>Authored and maintained by Edwin Onuonga.</em>
 </p>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,6 @@ By contributing, you agree that your contributions will be licensed under the re
 ---
 
 <p align="center">
-  <b>Feud</b> &copy; 2023-2025, Edwin Onuonga - Released under the <a href="https://opensource.org/licenses/MIT">MIT</a> license.<br/>
+  <b>Feud</b> &copy; 2023, Edwin Onuonga - Released under the <a href="https://opensource.org/licenses/MIT">MIT</a> license.<br/>
   <em>Authored and maintained by Edwin Onuonga.</em>
 </p>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Edwin Onuonga (eonu) <ed@eonu.net>
+Copyright (c) 2023 Edwin Onuonga (eonu) <ed@eonu.net>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <p align="center"><b>Not all arguments are bad.</b></p>
 </p>
 
-<img src="https://svgur.com/i/zk4.svg" align="right" width="100px">
+<img src="https://raw.githubusercontent.com/eonu/feud/master/docs/source/_static/images/logo/logo.png" align="right" width="100px">
 
 <p align="center">
   <em>Build powerful CLIs with simple idiomatic Python, driven by type hints.</em>
@@ -962,6 +962,6 @@ Feud is released under the [MIT](https://opensource.org/licenses/MIT) license.
 ---
 
 <p align="center">
-  <b>Feud</b> &copy; 2023-2025, Edwin Onuonga - Released under the <a href="https://opensource.org/licenses/MIT">MIT</a> license.<br/>
+  <b>Feud</b> &copy; 2023, Edwin Onuonga - Released under the <a href="https://opensource.org/licenses/MIT">MIT</a> license.<br/>
   <em>Authored and maintained by Edwin Onuonga.</em>
 </p>

--- a/docs/source/__init__.py
+++ b/docs/source/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).
@@ -18,7 +18,7 @@ import sys
 sys.path.insert(0, os.path.abspath("../.."))
 
 project = "feud"
-copyright = "2023-2025, Feud Developers"  # noqa: A001
+copyright = "2023, Feud Developers"  # noqa: A001
 author = "Edwin Onuonga (eonu)"
 release = "0.4.1"
 

--- a/feud/__init__.py
+++ b/feud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/_internal/__init__.py
+++ b/feud/_internal/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/_internal/_command.py
+++ b/feud/_internal/_command.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/_internal/_decorators.py
+++ b/feud/_internal/_decorators.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/_internal/_docstring.py
+++ b/feud/_internal/_docstring.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/_internal/_group.py
+++ b/feud/_internal/_group.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/_internal/_inflect.py
+++ b/feud/_internal/_inflect.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/_internal/_metaclass.py
+++ b/feud/_internal/_metaclass.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/_internal/_sections.py
+++ b/feud/_internal/_sections.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/_internal/_types/__init__.py
+++ b/feud/_internal/_types/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/_internal/_types/click.py
+++ b/feud/_internal/_types/click.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/_internal/_types/defaults.py
+++ b/feud/_internal/_types/defaults.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/click/__init__.py
+++ b/feud/click/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).
@@ -12,7 +12,7 @@ try:
     from rich_click import *
 
     is_rich = True
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     from click import *
 
     is_rich = False

--- a/feud/click/context.py
+++ b/feud/click/context.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/config.py
+++ b/feud/config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/core/__init__.py
+++ b/feud/core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/core/command.py
+++ b/feud/core/command.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/core/group.py
+++ b/feud/core/group.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/decorators.py
+++ b/feud/decorators.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/exceptions.py
+++ b/feud/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/typing/__init__.py
+++ b/feud/typing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/typing/custom.py
+++ b/feud/typing/custom.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/typing/pydantic.py
+++ b/feud/typing/pydantic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/typing/pydantic_extra_types.py
+++ b/feud/typing/pydantic_extra_types.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/typing/stdlib.py
+++ b/feud/typing/stdlib.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/typing/typing.py
+++ b/feud/typing/typing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/feud/version.py
+++ b/feud/version.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/make/__init__.py
+++ b/make/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/make/cov.py
+++ b/make/cov.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/make/docs.py
+++ b/make/docs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/make/lint.py
+++ b/make/lint.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/make/release.py
+++ b/make/release.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/make/tests.py
+++ b/make/tests.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+poetry = { version = 'latest', pyproject = 'pyproject.toml' }
+python = '3.13'
+
+[env]
+_.python.venv = ".venv"

--- a/notice.py
+++ b/notice.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).
@@ -12,7 +12,7 @@ https://github.com/fatiando/maintenance/issues/10#issuecomment-718754908
 from pathlib import Path
 
 notice = """
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: User Interfaces",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ click = "^8.1.0"
 docstring-parser = "^0.15"
 Pydantic = { version = "^2.0.3", optional = true, extras = ["email"] }
 rich-click = { version = "^1.6.1", optional = true }
-pydantic-extra-types = { version = "^2.1.0", optional = true, extras = ["all"] }
+# TODO: change to extras=["all"] (https://github.com/pydantic/pydantic-extra-types/issues/239)
+pydantic-extra-types = { version = "^2.1.0", optional = true, extras = ["phonenumbers", "pycountry", "semver", "python_ulid"] }
 
 [tool.poetry.extras]
 rich = ["rich-click"]

--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_click/__init__.py
+++ b/tests/unit/test_click/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_click/test_context.py
+++ b/tests/unit/test_click/test_context.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_core/__init__.py
+++ b/tests/unit/test_core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_core/fixtures/__init__.py
+++ b/tests/unit/test_core/fixtures/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_core/fixtures/module.py
+++ b/tests/unit/test_core/fixtures/module.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_core/test_command.py
+++ b/tests/unit/test_core/test_command.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_core/test_group.py
+++ b/tests/unit/test_core/test_group.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_core/test_run.py
+++ b/tests/unit/test_core/test_run.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/__init__.py
+++ b/tests/unit/test_internal/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_command.py
+++ b/tests/unit/test_internal/test_command.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_decorators.py
+++ b/tests/unit/test_internal/test_decorators.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_docstring.py
+++ b/tests/unit/test_internal/test_docstring.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_metaclass.py
+++ b/tests/unit/test_internal/test_metaclass.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_types/test_click/__init__.py
+++ b/tests/unit/test_internal/test_types/test_click/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_types/test_click/conftest.py
+++ b/tests/unit/test_internal/test_types/test_click/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_types/test_click/test_get_click_type/__init__.py
+++ b/tests/unit/test_internal/test_types/test_click/test_get_click_type/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_types/test_click/test_get_click_type/conftest.py
+++ b/tests/unit/test_internal/test_types/test_click/test_get_click_type/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_custom.py
+++ b/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_custom.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_literal.py
+++ b/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_literal.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_pydantic.py
+++ b/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_pydantic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_pydantic_extra_types.py
+++ b/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_pydantic_extra_types.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_stdlib.py
+++ b/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_stdlib.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_typing.py
+++ b/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_typing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_types/test_click/test_is_collection_type.py
+++ b/tests/unit/test_internal/test_types/test_click/test_is_collection_type.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_internal/test_types/test_click/test_metavars.py
+++ b/tests/unit/test_internal/test_types/test_click/test_metavars.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Feud Developers.
+# Copyright (c) 2023 Feud Developers.
 # Distributed under the terms of the MIT License (see the LICENSE file).
 # SPDX-License-Identifier: MIT
 # This source code is part of the Feud project (https://feud.wiki).

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ isolated_build = True
 
 [testenv:tests]
 allowlist_externals = poetry
-commands = poetry run invoke tests.install tests.doctest tests.unit {posargs}
+; commands = poetry run invoke tests.install tests.doctest tests.unit {posargs}
+commands = poetry run invoke tests.install tests.unit {posargs}
 
 [testenv:tests.doctest]
 allowlist_externals = poetry


### PR DESCRIPTION
## Support python v3.13, add `mise.toml` and remove `doctest`

- Officially support Python v3.13.
- Remove `doctest` temporarily due to strange circular import errors despite unit tests passing.
- Add `mise.toml` for development environments.
- Update copyright notice.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
