### PR TITLE
feat: add `pydantic_extra_types.S3Path` to `feud.typing`

### DIFF
--- a/docs/source/sections/typing/pydantic_extra_types.rst
+++ b/docs/source/sections/typing/pydantic_extra_types.rst
@@ -83,6 +83,11 @@ Phone number type
 
 - :py:obj:`pydantic_extra_types.phone_numbers.PhoneNumber` (``>= 2.1.0``)
 
+Path types
+----------
+
+- :py:obj:`pydantic_extra_types.s3.S3Path` (``>= 2.10.0``)
+
 Payment types
 -------------
 

--- a/feud/_internal/_types/click.py
+++ b/feud/_internal/_types/click.py
@@ -131,6 +131,12 @@ try:
 
         EXTRA_TYPES[SemanticVersion] = click.STRING
 
+    if version >= packaging.version.parse("2.10.0"):
+        from pydantic_extra_types.s3 import S3Path
+
+        # NOTE: pathlib.Path isn't ideal for S3 paths
+        EXTRA_TYPES[S3Path] = click.STRING
+
 except ImportError:
     EXTRA_TYPES = {}
 

--- a/feud/typing/pydantic_extra_types.py
+++ b/feud/typing/pydantic_extra_types.py
@@ -85,5 +85,10 @@ try:
 
         __all__.append("SemanticVersion")
 
+    if version >= packaging.version.parse("2.10.0"):
+        from pydantic_extra_types.s3 import S3Path
+
+        __all__.append("S3Path")
+
 except ImportError:
     pass

--- a/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_pydantic_extra_types.py
+++ b/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_pydantic_extra_types.py
@@ -39,6 +39,7 @@ from feud.config import Config
         (t.LanguageAlpha2, click.STRING),
         (t.LanguageName, click.STRING),
         (t.SemanticVersion, click.STRING),
+        (t.S3Path, click.STRING),
     ],
 )
 def test_pydantic_extra(


### PR DESCRIPTION
## Add `pydantic_extra_types.S3Path` to `feud.typing`

Add support for `pydantic_extra_types.s3.S3Path` to `feud.typing`.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
