### PR TITLE
feat: add `fractions.Fraction` to `feud.typing`

### DIFF
--- a/docs/source/sections/typing/stdlib.rst
+++ b/docs/source/sections/typing/stdlib.rst
@@ -12,8 +12,8 @@ The following Python standard library types can be used as type hints for Feud c
 .. tip::
 
     Types listed on this page from the :py:mod:`collections`, :py:mod:`datetime` :py:mod:`decimal`, 
-    :py:mod:`enum`, :py:mod:`pathlib` and :py:mod:`uuid` standard library modules are easily accessible
-    from the :py:mod:`feud.typing` module.
+    :py:mod:`enum`, :py:mod:`fractions`, :py:mod:`pathlib`, :py:mod:`uuid` and :py:mod:`typing` 
+    standard library modules are easily accessible from the :py:mod:`feud.typing` module.
 
     It is recommended to import the :py:mod:`feud.typing` module with an alias such as ``t`` for convenient short-hand use, e.g.
 
@@ -261,6 +261,7 @@ Number types can be used to indicate integers, floats or decimal numbers.
 - :py:obj:`int` should be used to specify integer inputs.
 - :py:obj:`float` should be used to specify fixed precision-floating point inputs.
 - :py:obj:`decimal.Decimal` should be used to specify arbitrary-precision floating point inputs.
+- :py:obj:`fractions.Fraction` should be used to specify fractions.
 
 .. seealso:: 
 

--- a/feud/_internal/_types/click.py
+++ b/feud/_internal/_types/click.py
@@ -9,6 +9,7 @@ import collections
 import datetime
 import decimal
 import enum
+import fractions
 import functools as ft
 import inspect
 import pathlib
@@ -54,6 +55,7 @@ BASE_TYPES = {
     int: click.INT,
     float: click.FLOAT,
     decimal.Decimal: click.FLOAT,
+    fractions.Fraction: click.FLOAT,
     bool: click.BOOL,
     uuid.UUID: click.UUID,
     **{path_type: click.Path() for path_type in PATH_TYPES},

--- a/feud/typing/stdlib.py
+++ b/feud/typing/stdlib.py
@@ -8,6 +8,7 @@
 - ``collections``
 - ``datetime``
 - ``decimal``
+- ``fractions``
 - ``enum``
 - ``pathlib``
 - ``uuid``
@@ -19,6 +20,7 @@ import collections
 import datetime
 import decimal
 import enum
+import fractions
 import pathlib
 import uuid
 from itertools import chain
@@ -28,6 +30,7 @@ types: dict[ModuleType, list[str]] = {
     collections: ["deque"],
     datetime: ["date", "datetime", "time", "timedelta"],
     decimal: ["Decimal"],
+    fractions: ["Fraction"],
     enum: ["Enum", "IntEnum", "StrEnum"],
     pathlib: ["Path"],
     uuid: ["UUID"],

--- a/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_stdlib.py
+++ b/tests/unit/test_internal/test_types/test_click/test_get_click_type/test_stdlib.py
@@ -28,6 +28,7 @@ from feud.config import Config
         ],
         (t.UUID, click.UUID),
         (t.Decimal, click.FLOAT),
+        (t.Fraction, click.FLOAT),
         (
             t.date,
             lambda x: isinstance(x, _types.click.DateTime)


### PR DESCRIPTION
## Add `fractions.Fraction` to `feud.typing`

Add support for `fractions.Fraction` to `feud.typing`.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
