### PR TITLE
feat: add `typing.Hashable` to `feud.typing`

### DIFF
--- a/feud/typing/typing.py
+++ b/feud/typing/typing.py
@@ -14,6 +14,7 @@ types: list[str] = [
     "Any",
     "Deque",
     "FrozenSet",
+    "Hashable",
     "List",
     "Literal",
     "NamedTuple",


### PR DESCRIPTION
## Add `typing.Hashable` to `feud.typing`

Add support for `typing.Hashable` to `feud.typing`.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
