### PR TITLE
style: update `ruff` to v0.8.4 and remove `self`/`cls` annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,13 @@ repos:
         pass_filenames: false
   # ruff check (w/autofix)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.3 # should match version in pyproject.toml
+    rev: v0.8.4 # should match version in pyproject.toml
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   # ruff format
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.3 # should match version in pyproject.toml
+    rev: v0.8.4 # should match version in pyproject.toml
     hooks:
       - id: ruff-format
   # pydoclint - docstring formatting

--- a/feud/_internal/_command.py
+++ b/feud/_internal/_command.py
@@ -28,7 +28,7 @@ class ParameterType(enum.Enum):
 
 @dataclasses.dataclass
 class ParameterSpec:
-    type: ParameterType | None = None  # noqa: A003
+    type: ParameterType | None = None
     hint: type | None = None  # type: ignore[valid-type]
     args: t.Sequence[str] = dataclasses.field(default_factory=list)
     kwargs: dict[str, t.Any] = dataclasses.field(default_factory=dict)
@@ -50,7 +50,7 @@ class CommandState:
     description: str | None = None
 
     def decorate(  # noqa: PLR0915
-        self: t.Self,
+        self,
         func: t.Callable,
     ) -> click.Command | click.Group:
         meta_vars: dict[str, str] = {}
@@ -160,7 +160,7 @@ class CommandState:
 
         return compiled
 
-    def get_meta_var(self: t.Self, param: click.Parameter) -> str | None:
+    def get_meta_var(self, param: click.Parameter) -> str | None:
         match param:
             case click.Argument():
                 return param.make_metavar()

--- a/feud/_internal/_inflect.py
+++ b/feud/_internal/_inflect.py
@@ -6,7 +6,7 @@
 import re
 import unicodedata
 
-__all__ = ["sanitize", "optionize", "negate_option", "negate_alias"]
+__all__ = ["negate_alias", "negate_option", "optionize", "sanitize"]
 
 
 def transliterate(string: str) -> str:
@@ -90,7 +90,7 @@ def parameterize(string: str, separator: str = "-") -> str:
     if separator:
         re_sep = re.escape(separator)
         # No more than one of the separator in a row.
-        string = re.sub(r"%s{2,}" % re_sep, separator, string)
+        string = re.sub(rf"{re_sep}{{2,}}", separator, string)
         # Remove leading/trailing separator.
         string = re.sub(rf"(?i)^{re_sep}|{re_sep}$", "", string)
 

--- a/feud/_internal/_meta.py
+++ b/feud/_internal/_meta.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TypedDict
 
-__all__ = ["NameDict", "FeudMeta"]
+__all__ = ["FeudMeta", "NameDict"]
 
 
 class NameDict(TypedDict):

--- a/feud/_internal/_types/click.py
+++ b/feud/_internal/_types/click.py
@@ -164,7 +164,7 @@ AnnotatedArgDict = t.Dict[int, t.Any]
 
 class DateTime(click.DateTime):
     def __init__(
-        self: t.Self,
+        self,
         *args: t.Any,
         datetime_type: type,
         show_default_format: bool,
@@ -176,7 +176,7 @@ class DateTime(click.DateTime):
         super().__init__(*args, **kwargs)
 
     def get_metavar(
-        self: t.Self,
+        self,
         param: click.Parameter,  # noqa: ARG002
     ) -> str:
         return (
@@ -186,7 +186,7 @@ class DateTime(click.DateTime):
         )
 
     def _try_to_convert_date(
-        self: t.Self,
+        self,
         value: t.Any,
         format: str,  # noqa: A002, ARG002
     ) -> t.Any | None:
@@ -198,7 +198,7 @@ class DateTime(click.DateTime):
 
 class Union(click.ParamType):
     def __init__(
-        self: t.Self,
+        self,
         *args: t.Any,
         types: list[click.ParamType],
         **kwargs: t.Any,
@@ -215,7 +215,7 @@ class Union(click.ParamType):
             return click_type.get_metavar(param) or click_type.name.upper()
         return None
 
-    def get_metavar(self: t.Self, param: click.Parameter) -> str:
+    def get_metavar(self, param: click.Parameter) -> str:
         metavars = [
             metavar
             for click_type in self.types
@@ -453,7 +453,7 @@ def resolve_annotated(
     if parent_args is None:
         return None
 
-    arg_list = list(parent_args.values())  # noqa: F841
+    arg_list = list(parent_args.values())
     two_field_subtype = t.Annotated[*arg_list[:2]]  # type: ignore[valid-type]
 
     # integer types

--- a/feud/click/context.py
+++ b/feud/click/context.py
@@ -34,7 +34,7 @@ class Context(click.Context):
 
     @classmethod
     def __get_pydantic_core_schema__(
-        cls: type[Context], _source: t.Any, _handler: t.Any
+        cls, _source: t.Any, _handler: t.Any
     ) -> core_schema.CoreSchema:
         """Override pydantic schema to validate as typing.Any."""
         return core_schema.any_schema()

--- a/feud/config.py
+++ b/feud/config.py
@@ -51,7 +51,7 @@ class Config(pyd.BaseModel):
     #: (as of ``rich-click`` v1.7.2).
     rich_click_kwargs: dict[str, t.Any] = {"show_arguments": True}
 
-    def __init__(self: t.Self, **kwargs: t.Any) -> None:
+    def __init__(self, **kwargs: t.Any) -> None:
         caller: str | None = None
         frame = inspect.currentframe()
         if frame and frame.f_back:
@@ -65,9 +65,7 @@ class Config(pyd.BaseModel):
         super().__init__(**kwargs)
 
     @classmethod
-    def _create(
-        cls: type[Config], base: Config | None = None, **kwargs: t.Any
-    ) -> Config:
+    def _create(cls, base: Config | None = None, **kwargs: t.Any) -> Config:
         config_kwargs = base.model_dump(exclude_unset=True) if base else {}
         for field in cls.model_fields:
             value: t.Any | None = kwargs.get(field)

--- a/feud/core/group.py
+++ b/feud/core/group.py
@@ -146,11 +146,7 @@ class Group(metaclass=_metaclass.GroupBase):
         return cls.__compile__()(args, **kwargs)
 
     @classmethod
-    def __compile__(
-        cls: type[Group],
-        *,
-        parent: click.Group | None = None,
-    ) -> click.Group:
+    def __compile__(cls, *, parent: click.Group | None = None) -> click.Group:
         """Compile the group into a :py:class:`click.Group`.
 
         .. warning::
@@ -203,7 +199,7 @@ class Group(metaclass=_metaclass.GroupBase):
         pass
 
     @classmethod
-    def __sections__(cls: type[Group]) -> list[feud.Section]:
+    def __sections__(cls) -> list[feud.Section]:
         """Sections to partition commands and subgroups into.
 
         These sections are displayed on the group help page if ``rich-click``
@@ -252,7 +248,7 @@ class Group(metaclass=_metaclass.GroupBase):
         ]
 
     @classmethod
-    def name(cls: type[Group]) -> str:
+    def name(cls) -> str:
         """Return the name of the group.
 
         Returns
@@ -271,7 +267,7 @@ class Group(metaclass=_metaclass.GroupBase):
         return cls.__feud_click_kwargs__["name"]
 
     @classmethod
-    def compile(cls: type[Group]) -> click.Group:  # noqa: A003
+    def compile(cls) -> click.Group:
         """Compile the group into a :py:class:`click.Group`.
 
         Returns
@@ -292,7 +288,7 @@ class Group(metaclass=_metaclass.GroupBase):
 
     @classmethod
     def commands(
-        cls: type[Group], *, name: bool = False
+        cls, *, name: bool = False
     ) -> list[click.Command] | list[str]:
         """Commands defined in the group.
 
@@ -325,9 +321,7 @@ class Group(metaclass=_metaclass.GroupBase):
         return commands
 
     @classmethod
-    def subgroups(
-        cls: type[Group], *, name: bool = False
-    ) -> list[type[Group]] | list[str]:
+    def subgroups(cls, *, name: bool = False) -> list[type[Group]] | list[str]:
         """Registered subgroups.
 
         Parameters
@@ -363,7 +357,7 @@ class Group(metaclass=_metaclass.GroupBase):
         return list(cls.__feud_subgroups__)
 
     @classmethod
-    def descendants(cls: type[Group]) -> OrderedDict[type[Group], OrderedDict]:
+    def descendants(cls) -> OrderedDict[type[Group], OrderedDict]:
         """Directed acyclic graph of subgroup descendants.
 
         Returns
@@ -405,17 +399,15 @@ class Group(metaclass=_metaclass.GroupBase):
         )
 
     @classmethod
-    def _descendants(cls: type[Group]) -> t.Iterator[type[Group]]:
+    def _descendants(cls) -> t.Iterator[type[Group]]:
         for group in cls.__feud_subgroups__:
             yield group
             yield from group._descendants()  # noqa: SLF001
 
     @classmethod
-    def _check_descendants(
-        cls: type[Group], __target: type[Group] | None = None, /
-    ) -> None:
-        group: type[Group] = __target or cls
-        if cls is __target:
+    def _check_descendants(cls, target: type[Group] | None = None, /) -> None:
+        group: type[Group] = target or cls
+        if cls is target:
             msg = f"Group {cls.__name__!r} cannot be a subgroup of itself."
             raise feud.RegistrationError(msg)
         if cls in group._descendants():  # noqa: SLF001
@@ -427,7 +419,7 @@ class Group(metaclass=_metaclass.GroupBase):
 
     @classmethod
     def register(
-        cls: type[Group],
+        cls,
         sub: type[Group] | list[type[Group]],
         /,
     ) -> None:
@@ -506,7 +498,7 @@ class Group(metaclass=_metaclass.GroupBase):
 
     @classmethod
     def deregister(
-        cls: type[Group],
+        cls,
         sub: type[Group] | list[type[Group]] | None = None,
         /,
     ) -> None:
@@ -596,7 +588,7 @@ class Group(metaclass=_metaclass.GroupBase):
 
     @classmethod
     def from_dict(
-        cls: type[Group],
+        cls,
         obj: dict[str, click.Command | type[Group] | t.Callable],
         /,
         **kwargs: t.Any,
@@ -684,7 +676,7 @@ class Group(metaclass=_metaclass.GroupBase):
 
     @classmethod
     def from_iter(
-        cls: type[Group],
+        cls,
         obj: t.Iterable[click.Command | type[Group] | t.Callable],
         /,
         **kwargs: t.Any,
@@ -752,7 +744,7 @@ class Group(metaclass=_metaclass.GroupBase):
 
     @classmethod
     def from_module(
-        cls: type[Group],
+        cls,
         obj: types.ModuleType,
         /,
         **kwargs: t.Any,
@@ -841,7 +833,7 @@ class Group(metaclass=_metaclass.GroupBase):
 
     @classmethod
     def add_commands(
-        cls: type[Group],
+        cls,
         commands: list[t.Callable | click.Command] | None = None,
         /,
         **kwargs: t.Callable | click.Command,

--- a/feud/typing/pydantic.py
+++ b/feud/typing/pydantic.py
@@ -39,10 +39,10 @@ if version >= packaging.version.parse("2.0.3"):
             "FutureDate",
             "FutureDatetime",
             "HttpUrl",
-            "ImportString",
             "IPvAnyAddress",
             "IPvAnyInterface",
             "IPvAnyNetwork",
+            "ImportString",
             "Json",
             "KafkaDsn",
             "MariaDBDsn",
@@ -96,7 +96,7 @@ if version >= packaging.version.parse("2.7.0"):
     __all__.extend(["ClickHouseDsn"])
 
 if version >= packaging.version.parse("2.7.1"):
-    __all__.extend(["FtpUrl", "WebsocketUrl", "AnyWebsocketUrl"])
+    __all__.extend(["AnyWebsocketUrl", "FtpUrl", "WebsocketUrl"])
 
 if version >= packaging.version.parse("2.9.0"):
     __all__.extend(["SnowflakeDsn"])

--- a/make/lint.py
+++ b/make/lint.py
@@ -33,7 +33,7 @@ def check(c: Config) -> None:
 def format_(c: Config) -> None:
     """Format Python files."""
     commands: list[str] = [
-        "poetry run ruff --fix .",
+        "poetry run ruff check --fix .",
         "poetry run ruff format .",
     ]
     for command in commands:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ tox = "4.11.3"
 pre-commit = ">=3"
 
 [tool.poetry.group.lint.dependencies]
-ruff = "0.1.3"
+ruff = "0.8.4"
 pydoclint = "0.3.8"
 
 [tool.poetry.group.docs.dependencies]
@@ -105,8 +105,8 @@ pytest-cov = "^4.1.0"
 mypy = "1.14.0"
 
 [tool.ruff]
-required-version = "0.1.3"
-select = [
+required-version = "0.8.4"
+lint.select = [
     "F",    # pyflakes: https://pypi.org/project/pyflakes/
     "E",    # pycodestyle (error): https://pypi.org/project/pycodestyle/
     "W",    # pycodestyle (warning): https://pypi.org/project/pycodestyle/
@@ -149,7 +149,7 @@ select = [
     "PERF", # perflint: https://pypi.org/project/perflint/
     "RUF",  # ruff
 ]
-ignore = [
+lint.ignore = [
     "ANN401",  # https://beta.ruff.rs/docs/rules/any-type/
     "B905",    # https://beta.ruff.rs/docs/rules/zip-without-explicit-strict/
     "TD003",   # https://beta.ruff.rs/docs/rules/missing-todo-link/
@@ -161,18 +161,18 @@ ignore = [
     "COM812",  # ruff format conflict
     "ISC001",  # ruff format conflict
     "ERA001",  # Found commented-out code
+    "UP006",   # Use deque/frozenset/set/list/tuple instead of Deque/FrozenSet/Set/List/Tuple
 ]
-ignore-init-module-imports = true # allow unused imports in __init__.py
 line-length = 79
-typing-modules = ["feud.typing"]
+lint.typing-modules = ["feud.typing"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
-[tool.ruff.flake8-annotations]
+[tool.ruff.lint.flake8-annotations]
 allow-star-arg-any = true
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["PLC0414", "F403", "F401", "F405"]
 "feud/typing/*.py" = ["PLC0414", "F403", "F401"]
 "tests/**/*.py" = ["D100", "D100", "D101", "D102", "D103", "D104"]          # temporary

--- a/tests/unit/test_core/test_group.py
+++ b/tests/unit/test_core/test_group.py
@@ -1152,7 +1152,7 @@ Options:
 
 
 def test_main_help_both_docstrings_with_override(
-    capsys: pytest.CaptureFixture
+    capsys: pytest.CaptureFixture,
 ) -> None:
     class Test(feud.Group, help="Overridden."):
         """This is a class-level docstring."""

--- a/tests/unit/test_core/test_run.py
+++ b/tests/unit/test_core/test_run.py
@@ -17,7 +17,7 @@ from feud import typing as t
 from feud._internal import _docstring
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-from fixtures import module  # noqa: E402
+from fixtures import module
 
 overrides: dict[str, t.Any] = {
     "name": "overridden",

--- a/tests/unit/test_internal/test_docstring.py
+++ b/tests/unit/test_internal/test_docstring.py
@@ -94,7 +94,7 @@ def test_get_description_function_multi_line_doc_with_f(mode: Mode) -> None:
 
 @pytest.mark.parametrize("mode", list(Mode))
 def test_get_description_function_single_line_doc_with_params(
-    mode: Mode
+    mode: Mode,
 ) -> None:
     def f(*, opt: int) -> None:
         """Line 1.
@@ -120,7 +120,7 @@ def test_get_description_function_single_line_doc_with_params(
 
 @pytest.mark.parametrize("mode", list(Mode))
 def test_get_description_function_multi_line_doc_with_params(
-    mode: Mode
+    mode: Mode,
 ) -> None:
     def f(*, opt: int) -> None:
         """Line 1.


### PR DESCRIPTION
## Update `ruff` to v0.8.4 and remove `self`/`cls` annotations

- Upgrade `ruff` from v0.1.3 to v0.8.4.
- Remove `self`/`cls` type annotations.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
